### PR TITLE
fix: made some properties optional in eventgrid topics and corrected the custom topic usage example

### DIFF
--- a/examples/custom-topics/README.md
+++ b/examples/custom-topics/README.md
@@ -6,7 +6,6 @@ This deploys topics and event subscriptions that fits more specific, custom use 
 
 ```hcl
 config = object({
-  name           = string
   resource_group = string
   location       = string
   custom_topics = optional(map(object({

--- a/examples/custom-topics/main.tf
+++ b/examples/custom-topics/main.tf
@@ -56,7 +56,6 @@ module "eventgrid" {
   naming = local.naming
 
   config = {
-    name           = module.naming.eventgrid_domain.name
     resource_group = module.rg.groups.demo.name
     location       = module.rg.groups.demo.location
 

--- a/main.tf
+++ b/main.tf
@@ -608,8 +608,8 @@ resource "azurerm_eventgrid_topic" "this" {
 
   resource_group_name           = coalesce(lookup(var.config, "resource_group", null), var.resource_group)
   location                      = coalesce(lookup(var.config, "location", null), var.location)
-  input_schema                  = each.value.input_schema
-  public_network_access_enabled = each.value.public_network_access_enabled
+  input_schema                  = try(each.value.input_schema, "EventGridSchema")
+  public_network_access_enabled = try(each.value.public_network_access_enabled, true)
   local_auth_enabled            = try(each.value.local_auth_enabled, false)
   tags                          = try(var.config.tags, var.tags, null)
   inbound_ip_rule               = try(each.value.inbound_ip_rule, null)


### PR DESCRIPTION
## Description

This PR made some properties optional in eventgrid topics and corrected the custom topic usage example

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)